### PR TITLE
Use echo -e to show colors in the windows Git Bash

### DIFF
--- a/gitrepos
+++ b/gitrepos
@@ -14,7 +14,7 @@ then
 			cd ${verzeichnis}
 			if [ -d .git ]
 			then
-				echo "\033[32m~~~~~ performing [ \033[33m\033[01mgit ${gitcmd}\033[0m\033[32m ] on [ \033[01m"${verzeichnis}"\033[0m \033[32m ] ~~~~~\033[0m"
+				echo -e "\033[32m~~~~~ performing [ \033[33m\033[01mgit ${gitcmd}\033[0m\033[32m ] on [ \033[01m"${verzeichnis}"\033[0m \033[32m ] ~~~~~\033[0m"
 				git ${gitcmd}
 			fi
 			cd ..


### PR DESCRIPTION
The parameter "-e" after the echo is necessary to show color in the (windows) Git Bash. Otherwise the output shows only the Ansi codes.
